### PR TITLE
Fixes issue #3220 and add some tests

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -628,17 +628,10 @@ public class JavaParserFacade {
      */
     protected Node findContainingTypeDeclOrObjectCreationExpr(Node node, String className) {
         Node parent = node;
-        boolean detachFlag = false;
         while (true) {
             parent = demandParentNode(parent);
             if (parent instanceof BodyDeclaration) {
                 if (parent instanceof TypeDeclaration && ((TypeDeclaration<?>) parent).getFullyQualifiedName().get().endsWith(className)) {
-                    return parent;
-                } else {
-                    detachFlag = true;
-                }
-            } else if (parent instanceof ObjectCreationExpr) {
-                if (detachFlag) {
                     return parent;
                 }
             }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3200Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue3200Test.java
@@ -1,0 +1,141 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class Issue3200Test {
+
+    @Test
+    public void test3200() {
+        ParserConfiguration config = new ParserConfiguration();
+        CombinedTypeSolver cts = new CombinedTypeSolver();
+        cts.add(new ReflectionTypeSolver(false));
+        config.setSymbolResolver(new JavaSymbolSolver(cts));
+        StaticJavaParser.setConfiguration(config);
+
+        String str = "public class Test {\n" +
+                "    private void bad() {\n" +
+                "        Test test = new Test();\n" +
+                "        test.setRunnable(\"\", new Runnable() {\n" +
+                "            @Override\n" +
+                "            public void run() {\n" +
+                "                getContext(Test.this);\n" +
+                "            }\n" +
+                "        });\n" +
+                "    }\n" +
+                "\n" +
+                "    private void getContext(Test test) {\n" +
+                "    }\n" +
+                "\n" +
+                "    private void setRunnable(String str, Runnable runnable) {\n" +
+                "    }\n" +
+                "}";
+        CompilationUnit cu = StaticJavaParser.parse(str);
+        List<MethodCallExpr> mce = cu.findAll(MethodCallExpr.class);
+        mce.forEach(m -> System.out.println(m.resolve().getQualifiedSignature()));
+    }
+
+
+    @Test
+    public void test1() {
+        ParserConfiguration config = new ParserConfiguration();
+        CombinedTypeSolver cts = new CombinedTypeSolver();
+        cts.add(new ReflectionTypeSolver(false));
+        config.setSymbolResolver(new JavaSymbolSolver(cts));
+        StaticJavaParser.setConfiguration(config);
+
+        String str = "public class Test {\n" +
+                "    void getContext(Test test) {  }\n" +
+                "    {\n" +
+                "        new Test () {\n" +
+                "            {\n" +
+                "                getContext(Test.this);\n" +
+                "            }\n" +
+                "        };\n" +
+                "    }\n" +
+                "}";
+        CompilationUnit cu = StaticJavaParser.parse(str);
+        MethodCallExpr mce = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration rmd = mce.resolve();
+        String sig = rmd.getQualifiedSignature();
+        System.out.println(sig);
+    }
+
+    @Test
+    public void test2() {
+        ParserConfiguration config = new ParserConfiguration();
+        CombinedTypeSolver cts = new CombinedTypeSolver();
+        cts.add(new ReflectionTypeSolver(false));
+        config.setSymbolResolver(new JavaSymbolSolver(cts));
+        StaticJavaParser.setConfiguration(config);
+
+        String str = "public class Test {\n" +
+                "    class Inner { }" +
+                "    void getContext(Test test) {  }\n" +
+                "    {\n" +
+                "        new Inner () {\n" +
+                "            {\n" +
+                "                getContext(Test.this);\n" +
+                "            }\n" +
+                "        };\n" +
+                "    }\n" +
+                "}";
+        CompilationUnit cu = StaticJavaParser.parse(str);
+
+        ClassOrInterfaceDeclaration t = cu.findFirst(ClassOrInterfaceDeclaration.class).get();
+        System.out.println(t.getFullyQualifiedName().get());
+        System.out.println(t.getFullyQualifiedName().get().endsWith("Test"));
+        MethodCallExpr mce = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration rmd = mce.resolve();
+        String sig = rmd.getQualifiedSignature();
+        System.out.println(sig);
+    }
+
+    @Test
+    public void test3() {
+        ParserConfiguration config = new ParserConfiguration();
+        CombinedTypeSolver cts = new CombinedTypeSolver();
+        cts.add(new ReflectionTypeSolver(false));
+        config.setSymbolResolver(new JavaSymbolSolver(cts));
+        StaticJavaParser.setConfiguration(config);
+
+        String str = "public class Test {\n" +
+                "    class Inner { }" +
+                "    void getContext(Test test) {  }\n" +
+                "    {\n" +
+                "        new Inner () {\n" +
+                "            {\n" +
+                "                getContext(new Test());\n" +
+                "            }\n" +
+                "        };\n" +
+                "    }\n" +
+                "}";
+        CompilationUnit cu = StaticJavaParser.parse(str);
+        MethodCallExpr mce = cu.findFirst(MethodCallExpr.class).get();
+        ResolvedMethodDeclaration rmd = mce.resolve();
+        String sig = rmd.getQualifiedSignature();
+        System.out.println(sig);
+    }
+
+    class Test3200 {
+        class Inner { }
+        void getContext(Test3200 test) { }
+        {
+            new Inner() {
+                {
+                    getContext(Test3200.this);
+                }
+            };
+        }
+    }
+}
+


### PR DESCRIPTION
Fixes #3220 . 
Problem: The main class "this" expression in the anonymous class cannot get the type correctly as a function parameter.
Reason: When it gets the parameter type, it will loop to get the parent node. If it is a declaration statement, it will judge whether the name of its type is the same as that of "this". However, when it gets the object creation statement, it will exit halfway. Personally, I don't think it's right.
Modify: Delete the exit code of the object creation statement.